### PR TITLE
fix: render markdown with ContentRenderer

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,8 +1,8 @@
 <template>
   <div>
     <Hero />
-    <!-- only mount ContentDoc when doc exists to avoid "Failed to resolve component" / runtime destructure errors -->
-    <ContentDoc v-if="doc" :doc="doc" />
+    <!-- render markdown content when doc exists -->
+    <ContentRenderer v-if="doc" :value="doc" />
     <!-- fallback if no doc -->
     <div v-else class="p-6">Content not found.</div>
     <ExperienceTimeline />


### PR DESCRIPTION
## Summary
- replace `<ContentDoc>` with `<ContentRenderer>` so Nuxt can resolve the component and render content safely

## Testing
- `npm run build` *(fails: GitHub fetch failed [GET] "https://api.github.com/users/patricktobias86/repos?per_page=100": <no response> fetch failed)*

------
https://chatgpt.com/codex/tasks/task_b_68ab880814748328b100bafc7c67ba20