### PR TITLE
feat: add dark mode support

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="min-h-screen bg-white text-gray-800">
+  <div :class="[{ dark: isDark }, 'min-h-screen bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100']">
     <SiteHeader />
     <main class="px-6 md:px-10 lg:px-20">
       <NuxtPage />
@@ -13,6 +13,8 @@
 // provide the header, footer and wrapper styling for the site.
 import SiteHeader from '~/components/SiteHeader.vue'
 import SiteFooter from '~/components/SiteFooter.vue'
+import { useTheme } from '~/composables/useTheme'
+const { isDark } = useTheme()
 useSchemaOrg([
   {
     "@type": "Person",

--- a/app/components/About.vue
+++ b/app/components/About.vue
@@ -3,10 +3,10 @@
   <article id="about" class="max-w-6xl mx-auto py-16">
     <h2 class="text-2xl font-semibold">About</h2>
     <div class="mt-8 leading-9 space-y-8">
-      <div class="p-6 rounded-3xl border shadow-soft">
+      <div class="p-6 rounded-3xl border dark:border-gray-700 shadow-soft">
         <p>I help teams <strong>automate marketing</strong>, <strong>optimize conversion</strong> and <strong>ship web projects</strong> across the Nordics.</p>
         <h3 class="font-medium">Highlights</h3>
-        <ul class="mt-3 list-disc pl-5 space-y-1 text-gray-700">
+        <ul class="mt-3 list-disc pl-5 space-y-1 text-gray-700 dark:text-gray-300">
         <li>Grew conversion <span
     class="inline-flex items-center justify-center rounded-full bg-emerald-100 px-2.5 py-0.5 text-emerald-700"
   ><Icon name="material-symbols:show-chart" /><p class="text-sm whitespace-nowrap">+66%</p>

--- a/app/components/ContactCta.vue
+++ b/app/components/ContactCta.vue
@@ -1,13 +1,13 @@
 <template>
   <section id="contact" class="max-w-6xl mx-auto py-20">
-    <div class="rounded-3xl border shadow-soft p-10 flex flex-col md:flex-row md:items-center md:justify-between">
+    <div class="rounded-3xl border dark:border-gray-700 shadow-soft p-10 flex flex-col md:flex-row md:items-center md:justify-between">
       <div>
         <h2 class="text-2xl font-semibold">Let’s improve your funnel</h2>
-        <p class="text-gray-600 mt-2">Automation, CRO, KPIs &amp; shipping web quickly.</p>
+        <p class="text-gray-600 dark:text-gray-300 mt-2">Automation, CRO, KPIs &amp; shipping web quickly.</p>
       </div>
       <div class="mt-6 md:mt-0 flex gap-4">
-        <a :href="`mailto:${runtime.public.contactEmail}`" class="px-5 py-3 rounded-xl bg-black text-white">Email me</a>
-        <a :href="`mailto:${runtime.public.contactEmail}`" target="_blank" class="px-5 py-3 rounded-xl border">Book a call</a>
+        <a :href="`mailto:${runtime.public.contactEmail}`" class="px-5 py-3 rounded-xl bg-black text-white dark:bg-white dark:text-black">Email me</a>
+        <a :href="`mailto:${runtime.public.contactEmail}`" target="_blank" class="px-5 py-3 rounded-xl border dark:border-gray-700">Book a call</a>
       </div>
     </div>
   </section>

--- a/app/components/ExperienceCards.vue
+++ b/app/components/ExperienceCards.vue
@@ -7,16 +7,16 @@
       <div
         v-for="(item, i) in itemsToRender"
         :key="i"
-        class="p-6 rounded-3xl border shadow-soft"
+        class="p-6 rounded-3xl border dark:border-gray-700 shadow-soft"
       >
         <div class="flex items-center justify-between">
           <h3 class="font-medium">
-            {{ item.role }} — <span class="text-gray-600">{{ item.org }}</span>
+            {{ item.role }} — <span class="text-gray-600 dark:text-gray-300">{{ item.org }}</span>
           </h3>
-          <span class="text-sm text-gray-500">{{ item.period }}</span>
+          <span class="text-sm text-gray-500 dark:text-gray-400">{{ item.period }}</span>
         </div>
 
-        <ul class="mt-3 list-disc pl-5 space-y-1 text-gray-700">
+        <ul class="mt-3 list-disc pl-5 space-y-1 text-gray-700 dark:text-gray-300">
           <li v-for="(b, j) in item.bullets" :key="j">{{ b }}</li>
         </ul>
       </div>

--- a/app/components/Hero.vue
+++ b/app/components/Hero.vue
@@ -4,21 +4,21 @@
       <h1 class="text-4xl md:text-5xl font-bold leading-tight">
         Marketing Automation &amp; Technical PM
       </h1>
-      <p class="mt-5 text-lg text-gray-600">
+      <p class="mt-5 text-lg text-gray-600 dark:text-gray-300">
         HubSpot automation, growth experiments, and multi-market web delivery across the Nordics.
       </p>
       <div class="mt-8 flex gap-4">
-        <a href="#contact" class="px-5 py-3 rounded-xl bg-black text-white shadow-soft">Start a project</a>
-        <a href="#projects" class="px-5 py-3 rounded-xl border">See my work</a>
+        <a href="#contact" class="px-5 py-3 rounded-xl bg-black text-white shadow-soft dark:bg-white dark:text-black">Start a project</a>
+        <a href="#projects" class="px-5 py-3 rounded-xl border dark:border-gray-700">See my work</a>
       </div>
     </div>
-    <div class="rounded-3xl p-8 border shadow-soft">
+    <div class="rounded-3xl p-8 border dark:border-gray-700 shadow-soft">
       <ul class="space-y-3 text-sm">
         <li><strong>Based in:</strong> {{ runtime.public.location }}</li>
         <li><strong>Email:</strong> <a :href="`mailto:${runtime.public.contactEmail}`" class="underline">{{ runtime.public.contactEmail }}</a></li>
         <li><strong>Phone:</strong> {{ runtime.public.contactPhone }}</li>
       </ul>
-      <p class="mt-6 text-gray-600">Award: Belron Exceptional Customer Service (2016). Education: Media &amp; Webdesign, Jensen Gymnasium.</p>
+      <p class="mt-6 text-gray-600 dark:text-gray-300">Award: Belron Exceptional Customer Service (2016). Education: Media &amp; Webdesign, Jensen Gymnasium.</p>
     </div>
   </section>
 </template>

--- a/app/components/ProjectsGrid.vue
+++ b/app/components/ProjectsGrid.vue
@@ -7,18 +7,18 @@ const { data: repos } = await useFetch('/api/github')
 <template>
   <section id="projects" class="max-w-6xl mx-auto py-16">
     <h2 class="text-2xl font-semibold">Selected Projects</h2>
-    <p class="text-gray-600 mt-2">Pulled from my GitHub at build time.</p>
+    <p class="text-gray-600 dark:text-gray-300 mt-2">Pulled from my GitHub at build time.</p>
     <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mt-8">
       <a
         v-for="r in repos?.repos"
         :key="r.url"
         :href="r.url"
         target="_blank"
-        class="block p-6 rounded-3xl border shadow-soft hover:-translate-y-0.5 transition"
+        class="block p-6 rounded-3xl border dark:border-gray-700 shadow-soft hover:-translate-y-0.5 transition"
       >
         <h3 class="font-medium">{{ r.name }}</h3>
-        <p class="text-sm text-gray-600 mt-2 line-clamp-3" v-if="r.desc">{{ r.desc }}</p>
-        <div class="mt-4 text-xs text-gray-500 flex gap-4">
+        <p class="text-sm text-gray-600 dark:text-gray-300 mt-2 line-clamp-3" v-if="r.desc">{{ r.desc }}</p>
+        <div class="mt-4 text-xs text-gray-500 dark:text-gray-400 flex gap-4">
           <span>★ {{ r.stars }}</span>
           <span v-if="r.lang">{{ r.lang }}</span>
         </div>

--- a/app/components/SiteFooter.vue
+++ b/app/components/SiteFooter.vue
@@ -1,6 +1,6 @@
 <template>
-  <footer class="border-t mt-20">
-    <div class="max-w-6xl mx-auto py-10 text-sm text-gray-500 flex items-center justify-between">
+  <footer class="border-t dark:border-gray-700 mt-20">
+    <div class="max-w-6xl mx-auto py-10 text-sm text-gray-500 dark:text-gray-400 flex items-center justify-between">
       <span>© {{ new Date().getFullYear() }} Patrick Danielsson</span>
       <div class="flex gap-4">
         <a href="https://github.com/patricktobias86" target="_blank">GitHub</a>

--- a/app/components/SiteHeader.vue
+++ b/app/components/SiteHeader.vue
@@ -1,11 +1,12 @@
 <template>
-  <header class="sticky top-0 z-50 backdrop-blur bg-white/80 border-b">
+  <header class="sticky top-0 z-50 backdrop-blur bg-white/80 dark:bg-gray-900/80 border-b dark:border-gray-700">
     <div class="max-w-6xl mx-auto flex items-center justify-between py-4">
       <NuxtLink to="/" class="font-semibold tracking-tight">Patrick Danielsson</NuxtLink>
-      <nav class="flex gap-6 text-sm">
+      <nav class="flex items-center gap-6 text-sm">
         <NuxtLink to="/#work">Work</NuxtLink>
         <NuxtLink to="/#projects">Projects</NuxtLink>
-        <NuxtLink to="/#contact" class="px-3 py-1.5 rounded-xl bg-black text-white shadow-soft">Contact</NuxtLink>
+        <NuxtLink to="/#contact" class="px-3 py-1.5 rounded-xl bg-black text-white shadow-soft dark:bg-white dark:text-black">Contact</NuxtLink>
+        <button @click="toggleTheme" class="px-3 py-1.5 rounded-xl border dark:border-gray-700">{{ isDark ? 'Light' : 'Dark' }}</button>
       </nav>
     </div>
   </header>
@@ -15,4 +16,6 @@
 // The header uses NuxtLink for client-side navigation. It stays sticky
 // at the top of the viewport and provides quick access to sections on
 // the homepage.
+import { useTheme } from '~/composables/useTheme'
+const { isDark, toggleTheme } = useTheme()
 </script>

--- a/app/composables/useTheme.ts
+++ b/app/composables/useTheme.ts
@@ -1,0 +1,22 @@
+// /composables/useTheme.ts
+export function useTheme() {
+  const isDark = useState<boolean>('isDark', () => false)
+
+  if (process.client) {
+    const stored = localStorage.getItem('theme')
+    if (stored) {
+      isDark.value = stored === 'dark'
+    } else {
+      isDark.value = window.matchMedia('(prefers-color-scheme: dark)').matches
+    }
+  }
+
+  function toggleTheme() {
+    isDark.value = !isDark.value
+    if (process.client) {
+      localStorage.setItem('theme', isDark.value ? 'dark' : 'light')
+    }
+  }
+
+  return { isDark, toggleTheme }
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,6 +3,7 @@ import type { Config } from 'tailwindcss'
 // Tailwind CSS configuration. This file extends the default color palette
 // with custom brand colours and a soft shadow used throughout the site.
 export default <Partial<Config>>{
+  darkMode: 'class',
   content: [
     '~/components/*.{vue,js,ts}',
     '~/composables/*.{vue,js,ts}',


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind and persist user preference
- add header toggle and dark styling across layout and key components

## Testing
- `npm run build` *(fails: GitHub fetch failed: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_b_68ade73ab8e08328be5f95e5fc9771ea